### PR TITLE
the writer now escapes invalid content

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,51 +21,53 @@ Finally the parser also adds the ability to use basic CSS selectors to find elem
 
 ```php5
 <?php
-	$xmlString = \arc\xml::preamble()
-	 .\arc\xml::rss(['version'=>'2.0'],
-	 	\arc\xml::channel(
-	 		\arc\xml::title('Wikipedia'),
-	 		\arc\xml::link('http://www.wikipedia.org'),
-	 		\arc\xml::description('This feed notifies you of new articles on Wikipedia.')
-	 	)
-	 );
+    use \arc\xml as x;
+    $xmlString = 
+        x::preamble()
+        .x::rss(['version'=>'2.0'],
+             x::channel(
+                 x::title('Wikipedia'),
+                 x::link('http://www.wikipedia.org'),
+                 x::description('This feed notifies you of new articles on Wikipedia.')
+             )
+        );
 ```
 
 ```php5
-	$xml = \arc\xml::parse($xmlString);
-	$title = $xml->channel->title->nodeValue; // SimpleXMLElement 'Wikipedia'
-	$titleTag = $xml->channel->title; // <title>Wikipedia</title>
+    $xml = \arc\xml::parse($xmlString);
+    $title = $xml->channel->title->nodeValue; // SimpleXMLElement 'Wikipedia'
+    $titleTag = $xml->channel->title; // <title>Wikipedia</title>
 ```
 
 CSS selectors
 -------------
 
 ```php5
-	$title = current($xml->find('title'));
+    $title = current($xml->find('title'));
 ```
 
 The find() method always returns an array, which may be empty. By using current() you get the first element found, or null if nothing was found.
 
 The following CSS selectors are supported:
 
-- 'tag1 tag2'<br>
-  This matches tag2 which is a descendant of tag1.
-- 'tag1 > tag2'<br>
-  This matches tag2 which is a direct child of tag1.
-- 'tag:first-child'<br>
-  This matches 'tag' only if its the first child.
-- 'tag1 + tag2'<br>
-  This matches tag2 only if its immediately preceded by tag1.
-- 'tag1 ~ tag2'<br>
-  This matches tag2 only if it has a previous sibling tag1.
-- 'tag[attr]'<br>
-  This matches 'tag' if it has the attribute 'attr'.
-- 'tag[attr="foo"]'<br>
-  This matches 'tag' if it has the attribute 'attr' with the value 'foo' in its value list.
-- 'tag#id'<br>
-  This matches any 'tag' with id 'id'.
-- '#id'<br>
-  This matches any element with id 'id'.
+- `tag1 tag2`<br>
+  This matches `tag2` which is a descendant of `tag1`.
+- `tag1 > tag2`<br>
+  This matches `tag2` which is a direct child of `tag1`.
+- `tag:first-child`<br>
+  This matches `tag` only if its the first child.
+- `tag1 + tag2`<br>
+  This matches `tag2` only if its immediately preceded by `tag1`.
+- `tag1 ~ tag2`<br>
+  This matches `tag2` only if it has a previous sibling `tag1`.
+- `tag[attr]`<br>
+  This matches `tag` if it has the attribute `attr`.
+- `tag[attr="foo"]`<br>
+  This matches `tag` if it has the attribute `attr` with the value `foo` in its value list.
+- `tag#id`<br>
+  This matches any `tag` with id `id`.
+- `#id`<br>
+  This matches any element with id `id`.
 
 SimpleXML
 ---------
@@ -73,14 +75,14 @@ SimpleXML
 The parsed XML behaves almost identical to a SimpleXMLElement, with the exceptions noted above. So you can access attributes just like SimpleXMLElement allows:
 
 ```php5
-	$version = $xml['version'];
-	$version = $xml->attributes('version');
+    $version = $xml['version'];
+    $version = $xml->attributes('version');
 ```
 
 You can walk through the node tree:
 
 ```php5
-	$title = $xml->channel->title;
+    $title = $xml->channel->title;
 ```
 
 Any method or property available in SimpleXMLElement is included in \arc\xml parsed data.
@@ -91,9 +93,9 @@ DOMElement
 In addition to SimpleXMLElement methods, you can also call any method that is available in DOMElement.
 
 ```php5
-	$version = $xml->getAttributes('version');
-	$title = $xml->getElementsByTagName('channel')[0]
-		->getElementsByTagName('title')[0];
+    $version = $xml->getAttributes('version');
+    $title = $xml->getElementsByTagName('channel')[0]
+        ->getElementsByTagName('title')[0];
 ```
 
 But right now you cannot access the properties of DOMElement. This will be fixed soonish.
@@ -106,14 +108,14 @@ The arc\xml parser also accepts partial XML content. It doesn't require a single
 ```php5
     $xmlString = <<< EOF
 <item>
-	<title>An item</title>
+    <title>An item</title>
 </item>
 <item>
-	<title>Another item</title>
+    <title>Another item</title>
 </item>
 EOF;
-	$xml = \arc\xml::parse($xmlString);
-	$titles = $xml->find('title');
+    $xml = \arc\xml::parse($xmlString);
+    $titles = $xml->find('title');
 ```
 
 And when you convert the xml back to a string, it will still be a partial XML fragment.
@@ -128,6 +130,12 @@ arc\xml::parse has the following differences:
   - You can use it with partial XML fragments.
   - No need to remember calling importNode() before appendChild() or insertBefore()
   - No need to switch between SimpleXML and DOMDocument, because you need that one method only available in the other API.
-  - When returning a list of elements, you always get a simple Array, not a magic NodeList.
+  - When returning a list of elements, you always get a standard array, not a magic NodeList.
 
-In addition arc\xml doubles as a simple way to generate valid and indented XML, with readable and self-validating code.
+In addition the arc\xml writer is a simple way to generate valid and indented XML, with readable and self-validating code.
+
+  - Filters all illegal characters from your XML
+  - Automatically translate &, < and > characters to &amp;, &lt; and &gt;
+  - Automatically translate " to &quot; in attributes
+
+You can include raw unfiltered XML with the \arc\xml::raw() method

--- a/src/xml.php
+++ b/src/xml.php
@@ -202,4 +202,8 @@ class xml
         return $preamble;
     }
 
+    public static function raw( $contents='' ) {
+        return new xml\RawXML($contents);
+    }
+
 }

--- a/src/xml/NodeListTrait.php
+++ b/src/xml/NodeListTrait.php
@@ -16,6 +16,7 @@ namespace arc\xml;
 trait NodeListTrait {
 
     protected $writer = null;
+    protected $invalidChars = [];
 
     /**
      * @param array $list
@@ -54,19 +55,24 @@ trait NodeListTrait {
         }
     }
 
+    protected function escape( $contents ) {
+        $contents = preg_replace('/[^\x{0009}\x{000a}\x{000d}\x{0020}-\x{D7FF}\x{E000}-\x{FFFD}]+/u', '', $contents);
+        return htmlspecialchars( $contents, ENT_XML1, 'UTF-8');
+    }
+
     protected function parseArgs( $args ) 
     {
         $attributes = array();
         $content = '';
         foreach ($args as $arg ) {
-            if (is_string( $arg )) {
-                $content .= $arg;
+            if (is_string( $arg ) ) {
+                $content .= $this->escape($arg);
             } else if (is_array( $arg )) {
                 foreach( $arg as $key => $subArg ) {
                     if (is_numeric( $key )) {
                         list( $subattributes, $subcontent ) = $this->parseArgs( $subArg );
                         $attributes = array_merge( $attributes, $subattributes);
-                        $content .= $subcontent;
+                        $content = \arc\xml::raw( $content . $subcontent );
                     } else {
                         $attributes[ $key ] = $subArg;
                     }

--- a/src/xml/RawXML.php
+++ b/src/xml/RawXML.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ * This file is part of the Ariadne Component Library.
+ *
+ * (c) Muze <info@muze.nl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace arc\xml;
+
+/**
+ * This is a container for raw xml content, which will not get escaped 
+ * when included by the \arc\xml\Writer or NodeList.
+ * @property string $contents
+ */
+class RawXML {
+    public $contents = '';
+
+    public function __construct($contents) 
+    {
+        $this->contents = $contents;
+    }
+
+    public function __toString()
+    {
+        return $this->contents;
+    }
+}

--- a/tests/xml.Test.php
+++ b/tests/xml.Test.php
@@ -13,7 +13,7 @@
 class TestXML extends PHPUnit_Framework_TestCase 
 {
 
-	var $RSSXML = '<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+    var $RSSXML = '<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <rss version="2.0">
         <channel>
                 <title>Wikipedia</title>
@@ -22,129 +22,152 @@ class TestXML extends PHPUnit_Framework_TestCase
         </channel>
 </rss>
 ';
-	var $incorrectXML = "<?xml standalone=\"false\"><rss></rss>";
-	var $namespacedXML = "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\" ?>\n<testroot xmlns:foo=\"http://www.example.com/\">\n<foo:bar>something</foo:bar><bar>something else</bar><bar foo:attr=\"an attribute\">something else again</bar>\n</testroot>";
+    var $incorrectXML = "<?xml standalone=\"false\"><rss></rss>";
+    var $namespacedXML = "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\" ?>\n<testroot xmlns:foo=\"http://www.example.com/\">\n<foo:bar>something</foo:bar><bar>something else</bar><bar foo:attr=\"an attribute\">something else again</bar>\n</testroot>";
 
-	function testXMLBasics() 
-	{
-		$preamble = \arc\xml::preamble();
-		$cdata = \arc\xml::cdata('Some " value');
-		$this->assertEquals( (string) $preamble, '<?xml version="1.0" ?>' );
-		$this->assertEquals( (string) $cdata, '<![CDATA[Some " value]]>' );
-		$comment = \arc\xml::comment('A comment');
-		$this->assertEquals( (string) $comment, '<!-- A comment -->' );
-	}
+    function testXMLBasics() 
+    {
+        $preamble = \arc\xml::preamble();
+        $cdata = \arc\xml::cdata('Some " value');
+        $this->assertEquals( (string) $preamble, '<?xml version="1.0" ?>' );
+        $this->assertEquals( (string) $cdata, '<![CDATA[Some " value]]>' );
+        $comment = \arc\xml::comment('A comment');
+        $this->assertEquals( (string) $comment, '<!-- A comment -->' );
+    }
 
-	function testXMLWriter() 
-	{
-		$xml = \arc\xml::ul( [ 'class' => 'menu' ],
-			\arc\xml::li('menu 1')
-			->li('menu 2 ',
-				\arc\xml::em('emphasized')
-			)
-		);
-		$this->assertEquals( "<ul class=\"menu\">\r\n\t<li>menu 1</li>\r\n\t<li>\r\n\t\tmenu 2 <em>emphasized</em>\r\n\t</li>\r\n</ul>", (string) $xml );
-	}
+    function testXMLWriter() 
+    {
+        $xml = \arc\xml::ul( [ 'class' => 'menu' ],
+            \arc\xml::li('menu 1')
+            ->li('menu 2 ',
+                \arc\xml::em('emphasized')
+            )
+        );
+        $this->assertEquals( "<ul class=\"menu\">\r\n\t<li>menu 1</li>\r\n\t<li>\r\n\t\tmenu 2 <em>emphasized</em>\r\n\t</li>\r\n</ul>", (string) $xml );
+    }
 
-	function testXMLParsing() 
-	{
-		$xml = \arc\xml::parse( $this->RSSXML );
-		$error = null;
-		$xmlString = ''.$xml;
-		$this->assertEquals( $this->RSSXML, $xmlString );
-		$this->assertTrue( $xml->channel->title == '<title>Wikipedia</title>' );
-		$this->assertTrue( $xml->channel->title->nodeValue == 'Wikipedia' );
+    function testXMLWriterEscaping()
+    {
+        $xml = \arc\xml::item(
+            [ 
+                'class' => 'in"valid<stuff>',
+                'inva"lid' => "this is \n just wrong"
+            ],
+            "Escape me\" < really &copy;".chr(8),
+            \arc\xml::subitem( 
+                \arc\xml::raw("<subsubitem>this should work</subsubsubitem>")
+            )
+        );
+        $expectedValue = <<< EOF
+<item class="in&quot;valid&lt;stuff&gt;" invalid="this is 
+ just wrong">\r
+\tEscape me" &lt; really &amp;copy;<subitem>\r
+\t\t<subsubitem>this should work</subsubsubitem>\r
+\t</subitem>\r
+</item>
+EOF;
+        $this->assertEquals( $expectedValue, (string) $xml );
+    }
 
-		try {
-				$result = \arc\xml::parse( $this->incorrectXML );
-		} catch( \arc\Exception $error ) {
-		}
-		$this->assertTrue( $error instanceof \arc\Exception );
-	}
+    function testXMLParsing() 
+    {
+        $xml = \arc\xml::parse( $this->RSSXML );
+        $error = null;
+        $xmlString = ''.$xml;
+        $this->assertEquals( $this->RSSXML, $xmlString );
+        $this->assertTrue( $xml->channel->title == '<title>Wikipedia</title>' );
+        $this->assertTrue( $xml->channel->title->nodeValue == 'Wikipedia' );
 
-	function testXMLFind() 
-	{
-		$xml = \arc\xml::parse( $this->RSSXML );
-		$title = $xml->find('channel title')[0];
-		$this->assertTrue( $title->nodeValue == 'Wikipedia' );
-	}
+        try {
+                $result = \arc\xml::parse( $this->incorrectXML );
+        } catch( \arc\Exception $error ) {
+        }
+        $this->assertTrue( $error instanceof \arc\Exception );
+    }
 
-	function testProxyForAttributes()
-	{
-		$xml = \arc\xml::parse( $this->RSSXML );
-		$this->assertEquals( '2.0', $xml['version'] );
-		$attributes = $xml->attributes();
-		$this->assertEquals( '2.0', $attributes['version']);
-		$version = $xml->getAttribute('version');
-		$this->assertEquals( '2.0', $version );
-	}
+    function testXMLFind() 
+    {
+        $xml = \arc\xml::parse( $this->RSSXML );
+        $title = $xml->find('channel title')[0];
+        $this->assertTrue( $title->nodeValue == 'Wikipedia' );
+    }
 
-	function testCSSSelectors()
-	{
-		$xmlString = \arc\xml::{'list'}(
-			\arc\xml::item(['class' => 'first item', 'id' => 'special'], 'item1',
-				\arc\xml::input(['type' => 'radio', 'checked' => 'checked' ], 'a radio')
-			),
-			\arc\xml::item(['class' => 'item special-class'], 'item2',
-				\arc\xml::item(['class' => 'item last', 'data' => 'extra data'], 'item3')
-			)
-		);
-		$xml = \arc\xml::parse($xmlString);
-		$selectors = [
-			'list item' => ['item1','item2','item3'],
-			'list > item' => ['item1','item2'],
-			'item:first-child' => ['item1','item3'],
-			'input:checked' => ['a radio'],
-			'item + item' => ['item2'],
-			'item ~ item' => ['item2'],
-			'item[data]' => ['item3'],
-			'item[data="extra data"]' => ['item3'],
-			'item[data="extra"]' => ['item3'],
-			'item#special' => ['item1'],
-			'#special' => ['item1'],
-			'item.first' => ['item1'],
-			'item.last' => ['item3'],
-			'item.item' => ['item1', 'item2', 'item3'],
-			'.first' => ['item1'],
-			'.last' => ['item3'],
-			'.item' => ['item1', 'item2', 'item3'],
-			'item.special-class' => ['item2'],
-			'list > item.item' => ['item1','item2'],
-			'list > item > item.last' => ['item3'],
-			'list > item ~ item' => ['item2']
-		];
+    function testProxyForAttributes()
+    {
+        $xml = \arc\xml::parse( $this->RSSXML );
+        $this->assertEquals( '2.0', $xml['version'] );
+        $attributes = $xml->attributes();
+        $this->assertEquals( '2.0', $attributes['version']);
+        $version = $xml->getAttribute('version');
+        $this->assertEquals( '2.0', $version );
+    }
 
-		foreach ( $selectors as $css => $expectedValues ) {
-			$result = $xml->find($css);
-			foreach ( $result as $index => $value ) {
-				$result[$index] = (string) trim($value->nodeValue);
-			}
-			$this->assertEquals( $expectedValues, $result, 'selector: '.$css );
-		}
-	}
+    function testCSSSelectors()
+    {
+        $xmlString = \arc\xml::{'list'}(
+            \arc\xml::item(['class' => 'first item', 'id' => 'special'], 'item1',
+                \arc\xml::input(['type' => 'radio', 'checked' => 'checked' ], 'a radio')
+            ),
+            \arc\xml::item(['class' => 'item special-class'], 'item2',
+                \arc\xml::item(['class' => 'item last', 'data' => 'extra data'], 'item3')
+            )
+        );
+        $xml = \arc\xml::parse($xmlString);
+        $selectors = [
+            'list item' => ['item1','item2','item3'],
+            'list > item' => ['item1','item2'],
+            'item:first-child' => ['item1','item3'],
+            'input:checked' => ['a radio'],
+            'item + item' => ['item2'],
+            'item ~ item' => ['item2'],
+            'item[data]' => ['item3'],
+            'item[data="extra data"]' => ['item3'],
+            'item[data="extra"]' => ['item3'],
+            'item#special' => ['item1'],
+            '#special' => ['item1'],
+            'item.first' => ['item1'],
+            'item.last' => ['item3'],
+            'item.item' => ['item1', 'item2', 'item3'],
+            '.first' => ['item1'],
+            '.last' => ['item3'],
+            '.item' => ['item1', 'item2', 'item3'],
+            'item.special-class' => ['item2'],
+            'list > item.item' => ['item1','item2'],
+            'list > item > item.last' => ['item3'],
+            'list > item ~ item' => ['item2']
+        ];
 
-	function testXMLUpdates()
-	{
-		$xml = \arc\xml::parse( $this->RSSXML );
-		$xml->channel->addChild('language','en-us');
-		$language = $xml->channel->language->nodeValue;
-		$this->assertEquals('en-us', (string) $language);
-		$xml->channel->language = 'nl-NL';
-		$this->assertEquals('nl-NL', (string) $xml->channel->language->nodeValue );
-		$xml['version'] = '1.0';
-		$this->assertEquals('1.0', $xml['version']);		
-		$category = \arc\xml::parse('<category>Encyclopedia</category>');
-		$xml->channel->appendChild( $category );
-		$cat = $xml->channel->category->nodeValue;
-		$this->assertEquals('Encyclopedia', (string) $cat);
-	}
+        foreach ( $selectors as $css => $expectedValues ) {
+            $result = $xml->find($css);
+            foreach ( $result as $index => $value ) {
+                $result[$index] = (string) trim($value->nodeValue);
+            }
+            $this->assertEquals( $expectedValues, $result, 'selector: '.$css );
+        }
+    }
 
-	function testGetElemById()
-	{
-		$xmlString = '<list><item id="item1">item 1</item><item id="item2">item 2</item></list>';
-		$xml = \arc\xml::parse($xmlString);
-		$item1 = $xml->getElementById('item1');
-		$this->assertEquals('item 1', (string) $item1->nodeValue );
-	}
+    function testXMLUpdates()
+    {
+        $xml = \arc\xml::parse( $this->RSSXML );
+        $xml->channel->addChild('language','en-us');
+        $language = $xml->channel->language->nodeValue;
+        $this->assertEquals('en-us', (string) $language);
+        $xml->channel->language = 'nl-NL';
+        $this->assertEquals('nl-NL', (string) $xml->channel->language->nodeValue );
+        $xml['version'] = '1.0';
+        $this->assertEquals('1.0', $xml['version']);
+        $category = \arc\xml::parse('<category>Encyclopedia</category>');
+        $xml->channel->appendChild( $category );
+        $cat = $xml->channel->category->nodeValue;
+        $this->assertEquals('Encyclopedia', (string) $cat);
+    }
+
+    function testGetElemById()
+    {
+        $xmlString = '<list><item id="item1">item 1</item><item id="item2">item 2</item></list>';
+        $xml = \arc\xml::parse($xmlString);
+        $item1 = $xml->getElementById('item1');
+        $this->assertEquals('item 1', (string) $item1->nodeValue );
+    }
 
 }


### PR DESCRIPTION
It removes characters that are outside of the valid range (e.g. most control characters)
added a arc\xml::raw() method to insert xml content that won't get escaped
any object passed as content, which has a __toString method, also won't get escaped
updated README